### PR TITLE
Update esmf version

### DIFF
--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -41,6 +41,12 @@ else if ( "$L_MACHINE" == odin ) then
    module --initial_load --no_redirect restore
    setenv MODULEPATH "/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
 
+else if [ "$L_MACHINE" = aws ]; then
+   set ENV="/scratch1/apps/lmod/lmod/init/csh"
+   source $ENV
+
+   module purge
+
 else
    module purge
 endif

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -43,6 +43,12 @@ elif [ "$L_MACHINE" = odin ]; then
    module --initial_load --no_redirect restore
    export MODULEPATH="/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
 
+elif [ "$L_MACHINE" = aws ]; then
+   export BASH_ENV="/scratch1/apps/lmod/lmod/init/bash"
+   source $BASH_ENV
+
+   module purge
+   
 else
    module purge
 fi

--- a/modulefiles/build_aws_intel
+++ b/modulefiles/build_aws_intel
@@ -26,7 +26,7 @@ module load-any png/1.6.35 libpng/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
 module load pio/2.5.2
-module load esmf/8.2.0
+module load esmf/8.3.0b09
 module load fms/2021.03
 
 module load bacio/2.4.1

--- a/modulefiles/build_aws_intel
+++ b/modulefiles/build_aws_intel
@@ -40,7 +40,7 @@ module load upp/10.0.10
 
 module load gftl-shared/v1.3.3
 module load yafyaml/v0.5.1
-module load mapl/2.11.0-esmf-8.2.0
+module load mapl/2.12.2-esmf-8.3.0b09
 
 module load gfsio/1.4.1
 module load landsfcutil/2.4.1


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Build failed (@ ufs-weather-model) due to outdated esmf version. I installed esmf/8.3.0b09 on the self hosted runner, and need to update the version specified in this file hopes of passing the CI build test.

## TESTS CONDUCTED: 
Have successfully be able to run `module load build_aws_intel`, have not tested the build. 

