### PR TITLE
[replace_set_namelist] Update Hera spack-stack locations to use Rocky8

### DIFF
--- a/modulefiles/build_hera_gnu.lua
+++ b/modulefiles/build_hera_gnu.lua
@@ -5,10 +5,7 @@ the NOAA RDHPC machine Hera using GNU 9.2.0
 
 whatis([===[Loads libraries needed for building the UFS SRW App on Hera using GNU 9.2.0 ]===])
 
--- When Hera switches from CentOS to Rocky, replace line withh correct path to spack-stack
--- If you want to use Rocky OS now, use line below
---prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-rocky8/install/modulefiles/Core")
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-rocky8/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles")
 
 load("stack-gcc/9.2.0")

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -8,10 +8,7 @@ whatis([===[Loads libraries needed for building the UFS SRW App on Hera ]===])
 prepend_path("MODULEPATH","/contrib/sutils/modulefiles")
 load("sutils")
 
--- When Hera switches from CentOS to Rocky, replace line withh correct path to spack-stack
--- If you want to use Rocky OS now, use line below
---prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-rocky8/install/modulefiles/Core")
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-rocky8/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles")
 
 stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Following today's Hera maintenance, the machine will default to use Rocky8 nodes.  In order to prepare, the spack-stack paths in `modulefiles/build_hera_intel.lua` and `modulefiles/build_hera_gnu.lua` need to be updated to point to the Rocky8 environments.  With PR [#1054](https://github.com/ufs-community/ufs-srweather-app/pull/1054) being merged today, making this change will ensure that develop is ready once the machine returns from maintenance.