### PR TITLE
[to_yaml] Update wrapper scripts to allow them to run using var_defns.yaml

### DIFF
--- a/ush/wrappers/run_fcst.sh
+++ b/ush/wrappers/run_fcst.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
+export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.yaml"
+. $USHdir/source_util_funcs.sh
+for sect in workflow ; do
+  source_yaml ${GLOBAL_VAR_DEFNS_FP} ${sect}
+done
 set -xa
-source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
 export cyc=${DATE_FIRST_CYCL:8:2}

--- a/ush/wrappers/run_get_ics.sh
+++ b/ush/wrappers/run_get_ics.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
+export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.yaml"
+. $USHdir/source_util_funcs.sh
+for sect in workflow task_get_extrn_ics ; do
+  source_yaml ${GLOBAL_VAR_DEFNS_FP} ${sect}
+done
 set -xa
-source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
 export cyc=${DATE_FIRST_CYCL:8:2}

--- a/ush/wrappers/run_get_lbcs.sh
+++ b/ush/wrappers/run_get_lbcs.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
+export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.yaml"
+. $USHdir/source_util_funcs.sh
+for sect in workflow task_get_extrn_lbcs ; do
+  source_yaml ${GLOBAL_VAR_DEFNS_FP} ${sect}
+done
 set -xa
-source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
 export cyc=${DATE_FIRST_CYCL:8:2}

--- a/ush/wrappers/run_make_grid.sh
+++ b/ush/wrappers/run_make_grid.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
+export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.yaml"
+. $USHdir/source_util_funcs.sh
+for sect in workflow ; do
+  source_yaml ${GLOBAL_VAR_DEFNS_FP} ${sect}
+done
 set -xa
-source ${GLOBAL_VAR_DEFNS_FP}
 
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}

--- a/ush/wrappers/run_make_ics.sh
+++ b/ush/wrappers/run_make_ics.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
+export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.yaml"
+. $USHdir/source_util_funcs.sh
+for sect in workflow ; do
+  source_yaml ${GLOBAL_VAR_DEFNS_FP} ${sect}
+done
 set -xa
-source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
 export cyc=${DATE_FIRST_CYCL:8:2}

--- a/ush/wrappers/run_make_lbcs.sh
+++ b/ush/wrappers/run_make_lbcs.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
+export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.yaml"
+. $USHdir/source_util_funcs.sh
+for sect in workflow ; do
+  source_yaml ${GLOBAL_VAR_DEFNS_FP} ${sect}
+done
 set -xa
-source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
 export cyc=${DATE_FIRST_CYCL:8:2}

--- a/ush/wrappers/run_make_orog.sh
+++ b/ush/wrappers/run_make_orog.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
+export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.yaml"
+. $USHdir/source_util_funcs.sh
+for sect in workflow ; do
+  source_yaml ${GLOBAL_VAR_DEFNS_FP} ${sect}
+done
 set -xa
-source ${GLOBAL_VAR_DEFNS_FP}
 
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}

--- a/ush/wrappers/run_make_sfc_climo.sh
+++ b/ush/wrappers/run_make_sfc_climo.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
+export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.yaml"
+. $USHdir/source_util_funcs.sh
+for sect in workflow ; do
+  source_yaml ${GLOBAL_VAR_DEFNS_FP} ${sect}
+done
 set -xa
-source ${GLOBAL_VAR_DEFNS_FP}
 
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}

--- a/ush/wrappers/run_post.sh
+++ b/ush/wrappers/run_post.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.sh"
+export GLOBAL_VAR_DEFNS_FP="${EXPTDIR}/var_defns.yaml"
+. $USHdir/source_util_funcs.sh
+for sect in workflow ; do
+  source_yaml ${GLOBAL_VAR_DEFNS_FP} ${sect}
+done
 set -xa
-source ${GLOBAL_VAR_DEFNS_FP}
 export CDATE=${DATE_FIRST_CYCL}
 export CYCLE_DIR=${EXPTDIR}/${CDATE}
 export cyc=${DATE_FIRST_CYCL:8:2}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
While running the Jenkins tests with the `to_yaml` branch in PR [#1098](https://github.com/ufs-community/ufs-srweather-app/pull/1098), the `Functional WorkflowTaskTests` stage failed immediately.  This stage runs wrapper scripts, not a workflow, which requires extra steps to work with the change from bash to YAML for `var_defns`.  I have made the necessary cahnges to the wrapper scripts to allow them to run and move past this stage.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
- [x] hera.intel - Ran the wrapper_srw_ftest.sh Jenkins script
- [x] hera.gnu - Ran the wrapper_srw_ftest.sh Jenkins script

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes