### PR TITLE
[to_yaml] Update .cicd/scripts/wrapper_srw_ftest.sh to add third argument to call to load_modules_run_task.sh

### DIFF
--- a/.cicd/scripts/wrapper_srw_ftest.sh
+++ b/.cicd/scripts/wrapper_srw_ftest.sh
@@ -24,7 +24,8 @@ fi
 if [[ "${SRW_PLATFORM}" == gaea ]]; then
     sed -i '15i #SBATCH --clusters=c5' ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh
     sed -i 's|qos=batch|qos=normal|g' ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh
-    sed -i 's|${JOBSdir}/JREGIONAL_RUN_POST|$USHdir/load_modules_run_task.sh "run_post" ${JOBSdir}/JREGIONAL_RUN_POST|g' ${WORKSPACE}/${SRW_PLATFORM}/ush/wrappers/run_post.sh
+    sed -i 's|00:30:00|00:45:00|g' ${WORKSPACE}/${SRW_PLATFORM}/.cicd/scripts/${workflow_cmd}_srw_ftest.sh
+    sed -i 's|${JOBSdir}/JREGIONAL_RUN_POST|$USHdir/load_modules_run_task.sh "gaea" "run_post" ${JOBSdir}/JREGIONAL_RUN_POST|g' ${WORKSPACE}/${SRW_PLATFORM}/ush/wrappers/run_post.sh
 fi
 
 if [[ "${SRW_PLATFORM}" == hera ]]; then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
In the last PR, I missed that the `wrapper_srw_ftest.sh` Jenkins script had specific changes to run the wrapper scripts on Gaea.  For Gaea, `load_modules_run_task.sh` is called for the `run_post` script.  The changes in `to_yaml` have added a third argument to the call to `load_modules_run_task.sh`, leading to the `Functional WorkflowTaskTests` on Gaea (all other machines are successfully running now).

This PR will add the third argument to the call, allowing the `Functional WorkflowTaskTests` to run successfully on Gaea.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
- [x] gaea.intel - The Functional WorkflowTasksTest successfully passed with these changes.

## CHECKLIST
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes